### PR TITLE
Added kicad-docker-run.cmd file for running on Windows

### DIFF
--- a/bin/kicad-docker-run.cmd
+++ b/bin/kicad-docker-run.cmd
@@ -1,0 +1,9 @@
+@echo off
+REM Docker config
+
+if %DOCKER_CMD_PATH%=="" set DOCKER_CMD_PATH=docker
+if %DOCKER_CONTAINER%=="" set DOCKER_CONTAINER=kicad-automation
+
+set DOCKER_RUN=%DOCKER_CMD_PATH% run --rm -it %DOCKER_VOLUMES% %DOCKER_CONTAINER% %*
+
+%DOCKER_RUN%


### PR DESCRIPTION
Currently the Makefile uses the `kicad-docker-run` script to configure the command to run docker. However, this is a shell script that does not work on Windows. It results in the following message:

```
'd:/path/to/kicad-tools/bin/kicad-docker-run' is not recognized as an internal or external command,
operable program or batch file.
```

This PR adds `kicad-docker-run.cmd` to `kicad-tools/bin/`, which will allow the Makefile to invoke `kicad-docker-run` on Windows (The make file does not need to be updated, Windows will use the `.cmd` file).

I've tested this with `make fabrication-outputs` and confirmed I get all the expected outputs.