### PR TITLE
Add quotes around variables used in if statements in the Windows batch script

### DIFF
--- a/bin/kicad-docker-run.cmd
+++ b/bin/kicad-docker-run.cmd
@@ -1,8 +1,8 @@
 @echo off
 REM Docker config
 
-if %DOCKER_CMD_PATH%=="" set DOCKER_CMD_PATH=docker
-if %DOCKER_CONTAINER%=="" set DOCKER_CONTAINER=kicad-automation
+if "%DOCKER_CMD_PATH%"=="" set DOCKER_CMD_PATH=docker
+if "%DOCKER_CONTAINER%"=="" set DOCKER_CONTAINER=kicad-automation
 
 set DOCKER_RUN=%DOCKER_CMD_PATH% run --rm -it %DOCKER_VOLUMES% %DOCKER_CONTAINER% %*
 


### PR DESCRIPTION
Hi. I made a minor error in the Windows script I merged a few days ago. The variables `DOCKER_CMD_PATH` and `DOCKER_CONTAINER` need to be surrounded by quotes when in the if statement.

When I had initially tested this I used:

```
set DOCKER_CMD_PATH=docker
set DOCKER_CONTAINER=kicad-automation
```

In the script just to verify it worked.

Later when testing:

```
if %DOCKER_CMD_PATH%=="" set DOCKER_CMD_PATH=docker
if %DOCKER_CONTAINER%=="" set DOCKER_CONTAINER=kicad-automation
```

`DOCKER_CMD_PATH` and `DOCKER_CONTAINER` were set in my environment from the previous test. If the variables were not set the if statement resolves to `if ==""` which then causes an error.

