### PR TITLE
fix incompliant to POSIX in Makefile

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -4,7 +4,7 @@ MAKEFILE_PATH := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 # in the same directory as the Makefile whose name ends in .pro
 # This matches what one would usually find with KiCad
 
-BOARD = $(shell  ls $(MAKEFILE_PATH)/*.pro | xargs -n 1 basename --suffix .pro |head -n 1)
+BOARD = $(shell  ls $(MAKEFILE_PATH)/*.pro | xargs -IXXX -n 1 basename XXX .pro | head -n 1)
 
 -include /opt/kicad-tools/etc/rules.mk
 


### PR DESCRIPTION
`--suffix` is a GNU extension.
This fix make Makefile to runnable on any POSIX compliant OS, such as macOS.