### PR TITLE
Add KiCost 1.1.2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,12 +70,9 @@ COPY etc/kiplot /opt/etc/kiplot
 
 # Install KiCost
 #
-# Disabled because KiCost depends on Octopart which no longer has a free API
-#RUN pip3 install 'kicost==1.0.4'
-#
-#RUN apt-get -y remove python3-pip && \
-#    rm -rf /var/lib/apt/lists/*
-#
+RUN pip3 install 'kicost==1.1.2'
+RUN apt-get -y remove python3-pip && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install the interactive BOM
 


### PR DESCRIPTION
It looks like KiCost was removed after the Octopart API access rules changed.  KiCost later changed to the Kitspace PartInfo API.  I added it back in.

I have not yet integrated it into the Makefile, or done any documentation work.