### PR TITLE
Tracespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,12 @@ RUN cd /opt/kiplot && pip3 install -e .
 COPY etc/kiplot /opt/etc/kiplot
 
 
+# Install tracespace
+# https://github.com/tracespace/tracespace
+RUN apt-get -y update && apt-get install -y npm
+RUN npm install -g @tracespace/cli
+
+
 # Install KiCost
 #
 # Disabled because KiCost depends on Octopart which no longer has a free API

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ To generate an HTML interactive BOM
 $ make interactive-bom
 ```
 
+To generate SVG graphics with board layout and assembly
+```
+$ make draw
+```
+
 If you need to log into the docker instance to debug something, there's a makefile target for that, too
 
 ```

--- a/etc/rules.mk
+++ b/etc/rules.mk
@@ -59,12 +59,20 @@ gerbers: dirs
 dirs:
 	mkdir -p $(OUTPUT_PATH)
 	mkdir -p $(OUTPUT_PATH)/layout
+	mkdir -p $(OUTPUT_PATH)/layout/board && mkdir -p $(OUTPUT_PATH)/layout/assembly # && mkdir -p $(OUTPUT_PATH)/layout/docs
 	mkdir -p $(OUTPUT_PATH)/bom/interactive
 	mkdir -p $(OUTPUT_PATH)/schematic
 
 schematic: schematic-svg schematic-pdf
 
 
+draw: draw-board draw-assembly
+draw-board: gerbers
+	$(DOCKER_RUN) tracespace -L --out=/output/layout/board /output/layout/gerber/*Edge_Cuts.gbr /output/layout/gerber/*.drl gerber/*Cu.gbr /output/layout/gerber/*Mask.gbr /output/layout/gerber/*Paste.gbr /output/layout/gerber/*SilkS.gbr
+draw-assembly: gerbers
+	$(DOCKER_RUN) tracespace -B --out=/output/layout/assembly /output/layout/gerber/*Fab.gbr
+#draw-docs: gerbers
+#	$(DOCKER_RUN) tracespace -L --out=/output/layout/docs /output/layout/gerber/*Edge_Cuts.gbr /output/layout/gerber/*.drl gerber/*User.gbr
 
 interactive-bom: dirs
 	$(DOCKER_RUN) sh /opt/InteractiveHtmlBom/make-interactive-bom /kicad-project/$(BOARD_RELATIVE_PATH)

--- a/etc/rules.mk
+++ b/etc/rules.mk
@@ -68,11 +68,9 @@ schematic: schematic-svg schematic-pdf
 
 draw: draw-board draw-assembly
 draw-board: gerbers
-	$(DOCKER_RUN) tracespace -L --out=/output/layout/board /output/layout/gerber/*Edge_Cuts.gbr /output/layout/gerber/*.drl gerber/*Cu.gbr /output/layout/gerber/*Mask.gbr /output/layout/gerber/*Paste.gbr /output/layout/gerber/*SilkS.gbr
+	$(DOCKER_RUN) tracespace -L --out=/output/layout/board /output/layout/gerber/*Edge_Cuts.gbr /output/layout/gerber/*.drl /output/layout/gerber/*Mask.gbr /output/layout/gerber/*SilkS.gbr /output/layout/gerber/*Cu.gbr
 draw-assembly: gerbers
 	$(DOCKER_RUN) tracespace -B --out=/output/layout/assembly /output/layout/gerber/*Fab.gbr
-#draw-docs: gerbers
-#	$(DOCKER_RUN) tracespace -L --out=/output/layout/docs /output/layout/gerber/*Edge_Cuts.gbr /output/layout/gerber/*.drl gerber/*User.gbr
 
 interactive-bom: dirs
 	$(DOCKER_RUN) sh /opt/InteractiveHtmlBom/make-interactive-bom /kicad-project/$(BOARD_RELATIVE_PATH)


### PR DESCRIPTION
with this pull request [tracespace](https://github.com/tracespace/tracespace) is included to generate svgs from gerbers.
4 svgs are generated:
 * board top view (F.SilkS, F.Mask, F.Cu)
 * board bottom view (B.SilkS, B.Mask, B.Cu)
 * assembly top view (F.Fab)
 * assembly bottom view (B.Fab)