### PR TITLE
Build and publish Docker image to Github Container Registry

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,30 @@
+name: Build and Publish to GHCR
+on: 
+  push:
+    branches: master
+
+jobs:
+  build:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@master
+      with: 
+        submodules: true
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1 
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_TOKEN }}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Build and Push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 FROM ubuntu:bionic
 MAINTAINER Jesse Vincent <jesse@keyboard.io>
 LABEL Description="Minimal KiCad image based on Ubuntu"
-
+LABEL org.opencontainers.image.source https://github.com/obra/kicad-tools
 
 ADD upstream/kicad-automation-scripts/kicad-ppa.pgp .
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All of this is built on other projects:
 
 As of this writing, these tools target KiCad 5.1, running in a Docker container. While Docker does add a small amount of overhead, it helps compartmentalize the complexity of orchestrating these tools and (most importantly) makes it possible to generate schematic output from `eeschema` by running KiCad on a known configuration of an Ubuntu machine with a headless virtual X server.
 
-Theoretically, Dockerization makes it possible to run these tools on Windows or MacOS, though that is as-yet untested.
+Dockerization makes it possible to run these tools consistently on different platforms; macOS and Linux have been tested, Windows should also work though that is as-yet untested.
 
 Before setting up this package, you should have both Docker and git installed on your workstation.
 
@@ -40,7 +40,13 @@ Before setting up this package, you should have both Docker and git installed on
 	make
 	```
 
-This will spin for a while, downloading Ubuntu, KiCad, and the various tools we use.
+This will spin for a while, downloading Ubuntu, KiCad, and the various tools we use. 
+
+Alternatively, you can use the pre-built image from Github Container Registry:
+
+    ```
+    docker image tag ghcr.io/obra/kicad-tools:latest kicad-automation
+    ```
 
 If you get an error about being unable to connect to Docker, your Docker configuration
 may require you to 'sudo' to run Docker. In that case
@@ -58,6 +64,11 @@ You will need to restart your shell before it picks up any changes to your `.bas
 If you'd prefer to be able to run Docker containers without `sudo`, 
 you can find instructions for that here: 
 https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user
+
+4. On macOS, install 'realpath' using:
+    ```
+    brew install coreutils
+    ```
 
 
 You can verify that everything you've done so far is working by typing 


### PR DESCRIPTION
This PR adds CI using Github Actions. Commits to `master` should be built and published to Github Container Registry, at `ghcr.io/obra/kicad-tools`. This is similar to what is being asked for in #11

To set the CI process up, you will need to do the following:
* Create a personal access token, with permission to Write Packages. Ideally, don't give this token scope to do anything else.
* Add the token to this repo as a Secret, named `GHCR_TOKEN`.

I've also updated the README to explain how this image can be used.

I've also tested that this works on macOS - all is smooth, except for needing `realpath` which can be installed using `brew`.

Things that might be worth considering down the line, but not covered in this PR:
* Versioned releases
* Splitting into two repos - one for the KiCad base image, one for the tools / scripts that get added

EDIT:
After the first build has completed, you will need to make the images public at the following link: https://github.com/users/obra/packages/container/kicad-tools/settings