### PR TITLE
Support KiCad 5.99

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/openscopeproject/InteractiveHtmlBom
 [submodule "upstream/kicad-automation-scripts"]
 	path = upstream/kicad-automation-scripts
-	url = https://github.com/obra/kicad-automation-scripts
+	url = https://github.com/kubesail/kicad-automation-scripts
 [submodule "upstream/kiplot"]
 	path = upstream/kiplot
 	url = https://github.com/johnbeard/kiplot

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+export HOME=/root
+
+if [ -n "$SAVE_SCREENCAST" ]; then
+  SCREENCAST_ARG="--screencast_dir /output"
+else
+  echo "SAVE_SCREENCAST env not set... not saving screencast"
+fi
+
+case $1 in
+  bom)
+    python \
+        -m kicad-automation.eeschema.export_bom \
+        --schematic $2 \
+        --output_dir $3 \
+        ${SCREENCAST_ARG} \
+        export
+    ;;
+
+  *)
+    echo -n "unknown cmd"
+    ;;
+esac


### PR DESCRIPTION
I'd recommend not taking any action on this PR until KiCad 6 is officially released, but since I'm using the 5.99 nightly preview, I wanted to go ahead and share how I've adapted this code to work with the nightly releases.

Most of the script changes are in the kicad-automation-scripts repo (https://github.com/kubesail/kicad-automation-scripts/commit/8e0a29bab7cbc36f966fa9c1f12d4342a823ff92#diff-0d05120edf1237cd3614c6794ebe2ddd2455a290067df3c0165108bab0b3c0d2), but there are some significant changes to the Dockerfile too.

KiCad 6 will include an eeschema API, but I can't find any documentation on that currently. It will be great to use that and ditch xvfb once its out!
