### PR TITLE
Add screencast option for bom and schematic targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,16 @@ To compare the version of my_board.sch in `master` to the version as of tag `rev
 ```
 $ git schematic-diff master rev1 my_board.sch
 ```
+
+### Capturing a Screencast of Schematic and BOM Operations
+
+For the `bom`, `schematic-pdf`, and `schematic-svg` targets, it is possible to
+generate a screencast of the GUI operations performed in the docker container.
+This may be helpful to debug problems with the expected output.
+
+To enable this, add `DO_SCREENCAST=1` to your make command line, like this:
+
+    make bom DO_SCREENCAST=1
+
+You will end up with a `.ogv.` file in the output directory. You can view the
+screencast with VLC or other tool that can decode `.ogv` files.

--- a/etc/rules.mk
+++ b/etc/rules.mk
@@ -28,6 +28,12 @@ DOCKER_RUN := $(TOOLS_HOME)/bin/kicad-docker-run
 
 
 
+# screencast option to help debug
+ifeq ($(DO_SCREENCAST), 1)
+	SCREENCAST_OPT=--screencast_dir /output
+else
+	SCREENCAST_OPT=
+endif
 
 
 all: 
@@ -70,12 +76,12 @@ interactive-bom: dirs
 	$(DOCKER_RUN) sh /opt/InteractiveHtmlBom/make-interactive-bom /kicad-project/$(BOARD_RELATIVE_PATH)
 
 bom: dirs
-	$(DOCKER_RUN) python -m kicad-automation.eeschema.export_bom --schematic /kicad-project/$(SCHEMATIC_RELATIVE_PATH)  --output_dir /output/bom/ export
+	$(DOCKER_RUN) python -m kicad-automation.eeschema.export_bom --schematic /kicad-project/$(SCHEMATIC_RELATIVE_PATH)  --output_dir /output/bom/ $(SCREENCAST_OPT) export
 
 schematic-pdf: dirs
-	$(DOCKER_RUN) python -m kicad-automation.eeschema.schematic --schematic /kicad-project/$(SCHEMATIC_RELATIVE_PATH) --output_dir /output/schematic/pdf export --all_pages  -f pdf 
+	$(DOCKER_RUN) python -m kicad-automation.eeschema.schematic --schematic /kicad-project/$(SCHEMATIC_RELATIVE_PATH) --output_dir /output/schematic/pdf $(SCREENCAST_OPT) export --all_pages  -f pdf 
 schematic-svg: dirs
-	$(DOCKER_RUN) python -m kicad-automation.eeschema.schematic --schematic /kicad-project/$(SCHEMATIC_RELATIVE_PATH) --output_dir /output/schematic/svg export --all_pages  -f svg
+	$(DOCKER_RUN) python -m kicad-automation.eeschema.schematic --schematic /kicad-project/$(SCHEMATIC_RELATIVE_PATH) --output_dir /output/schematic/svg $(SCREENCAST_OPT) export --all_pages  -f svg
 
 docker-shell:
 	$(DOCKER_RUN) bash


### PR DESCRIPTION
This pull request allows a user to add DO_SCREENCAST=1 to the bom or schematic targets to generate a screencast of the docker container GUI operations. It might help with debugging problems. If the user does not add the macro, then the scripts behavior is unchanged.