### PR TITLE
Move bom.csv to .bak before regenerating, prevents hang #27

### DIFF
--- a/etc/rules.mk
+++ b/etc/rules.mk
@@ -76,6 +76,7 @@ interactive-bom: dirs
 	$(DOCKER_RUN) sh /opt/InteractiveHtmlBom/make-interactive-bom /kicad-project/$(BOARD_RELATIVE_PATH)
 
 bom: dirs
+	-mv -f $(OUTPUT_PATH)/bom/bom.csv $(OUTPUT_PATH)/bom/bom.csv.bak
 	$(DOCKER_RUN) python -m kicad-automation.eeschema.export_bom --schematic /kicad-project/$(SCHEMATIC_RELATIVE_PATH)  --output_dir /output/bom/ $(SCREENCAST_OPT) export
 
 schematic-pdf: dirs

--- a/etc/rules.mk
+++ b/etc/rules.mk
@@ -76,7 +76,7 @@ interactive-bom: dirs
 	$(DOCKER_RUN) sh /opt/InteractiveHtmlBom/make-interactive-bom /kicad-project/$(BOARD_RELATIVE_PATH)
 
 bom: dirs
-	-mv -f $(OUTPUT_PATH)/bom/bom.csv $(OUTPUT_PATH)/bom/bom.csv.bak
+	rm -f "$(OUTPUT_PATH)/bom/bom.csv"
 	$(DOCKER_RUN) python -m kicad-automation.eeschema.export_bom --schematic /kicad-project/$(SCHEMATIC_RELATIVE_PATH)  --output_dir /output/bom/ $(SCREENCAST_OPT) export
 
 schematic-pdf: dirs


### PR DESCRIPTION
This resolves the problem where `make bom` hangs if bom.csv already exists (#27). It copies it to bom.csv.bak if it exists. If it does not exist, an error message appears in the output but it does not stop the make.

    mv: rename /stuff/bom/bom.csv to /stuff/bom/bom.csv.bak: No such file or directory
    make: [bom] Error 1 (ignored)

If you want to prevent the error message from appearing, I can add `2>/dev/null`. However, there are a lot of other error appearing in the output already regarding pixman, and xserver stuff.